### PR TITLE
Updated file naming to limit character length

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function downloadStuff() {
 
         samples.forEach(sample => {
             const description = sample.description.replace(/[/\\?%*:|"<>.]/g, '');
-            const filename = `sounds/${description}${sample.location}`;
+            const filename = `sounds/${description.substring(0, 235)} - ${sample.location}`;
 
             console.log(`downloading then saving ${filename}`);
 


### PR DESCRIPTION
I found that some files had names longer than the character limit on my hard drive, so added a line to limit this.